### PR TITLE
change the go build invocation so paths from the root are used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DESTDIR =
 all: goshi
 
 goshi:
-	cd cmd/goshi && go build
+	go build -o cmd/goshi/goshi ./cmd/goshi
 
 clean:
 	rm -f goshi


### PR DESCRIPTION
This makes suitable to use `project-compile` from Emacs and have correct paths in the `*Compile*` buffer :-)